### PR TITLE
Load previous session

### DIFF
--- a/src/com/connectsdk/service/CastService.java
+++ b/src/com/connectsdk/service/CastService.java
@@ -355,9 +355,12 @@ public class CastService extends DeviceService implements MediaPlayer, MediaCont
         if (mMediaPlayer.getMediaInfo() != null) {
             String url = mMediaPlayer.getMediaInfo().getContentId();
             String mimeType = mMediaPlayer.getMediaInfo().getContentType();
-            String iconUrl = mMediaPlayer.getMediaInfo().getMetadata().getImages().get(0).getUrl().toString();
             String title = mMediaPlayer.getMediaInfo().getMetadata().getString(MediaMetadata.KEY_TITLE);
             String description =  mMediaPlayer.getMediaInfo().getMetadata().getString(MediaMetadata.KEY_SUBTITLE);
+            String iconUrl = null;
+            if (!mMediaPlayer.getMediaInfo().getMetadata().getImages().isEmpty()) {
+                iconUrl = mMediaPlayer.getMediaInfo().getMetadata().getImages().get(0).getUrl().toString();
+            }
 
             ArrayList<ImageInfo> list = new ArrayList<ImageInfo>();
             list.add(new ImageInfo(iconUrl));

--- a/src/com/connectsdk/service/CastService.java
+++ b/src/com/connectsdk/service/CastService.java
@@ -399,8 +399,10 @@ public class CastService extends DeviceService implements MediaPlayer, MediaCont
                             for (int i = 0; i < subscription.getListeners().size(); i++) {
                                 @SuppressWarnings("unchecked")
                                 ResponseListener<Object> listener = (ResponseListener<Object>) subscription.getListeners().get(i);
-                                PlayStateStatus status = PlayStateStatus.convertPlayerStateToPlayStateStatus(mMediaPlayer.getMediaStatus().getPlayerState());
-                                Util.postSuccess(listener, status);
+                                if (mMediaPlayer != null && mMediaPlayer.getMediaStatus() != null) {
+                                    PlayStateStatus status = PlayStateStatus.convertPlayerStateToPlayStateStatus(mMediaPlayer.getMediaStatus().getPlayerState());
+                                    Util.postSuccess(listener, status);
+                                }
                             }
                         }
                     }

--- a/src/com/connectsdk/service/CastService.java
+++ b/src/com/connectsdk/service/CastService.java
@@ -50,6 +50,7 @@ import com.google.android.gms.cast.Cast;
 import com.google.android.gms.cast.Cast.ApplicationConnectionResult;
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.CastMediaControlIntent;
+import com.google.android.gms.cast.LaunchOptions;
 import com.google.android.gms.cast.MediaMetadata;
 import com.google.android.gms.cast.RemoteMediaPlayer;
 import com.google.android.gms.cast.RemoteMediaPlayer.MediaChannelResult;
@@ -565,7 +566,9 @@ public class CastService extends DeviceService implements MediaPlayer, MediaCont
                 if (Cast.CastApi.getApplicationStatus(mApiClient) == null || (!mediaAppId.equals(currentAppId)))
                     relaunchIfRunning = true;
 
-                Cast.CastApi.launchApplication(mApiClient, mediaAppId, relaunchIfRunning).setResultCallback(webAppLaunchCallback);
+                LaunchOptions options = new LaunchOptions();
+                options.setRelaunchIfRunning(relaunchIfRunning);
+                Cast.CastApi.launchApplication(mApiClient, mediaAppId, options).setResultCallback(webAppLaunchCallback);
             }
         };
 
@@ -618,20 +621,23 @@ public class CastService extends DeviceService implements MediaPlayer, MediaCont
 
             @Override
             public void onConnected() {
-                Cast.CastApi.launchApplication(mApiClient, webAppId, relaunchIfRunning).setResultCallback(
-                        new ApplicationConnectionResultCallback(new LaunchWebAppListener() {
+                LaunchOptions options = new LaunchOptions();
+                options.setRelaunchIfRunning(relaunchIfRunning);
 
-                            @Override
-                            public void onSuccess(WebAppSession webAppSession) {
-                                Util.postSuccess(listener, webAppSession);
-                            }
+                Cast.CastApi.launchApplication(mApiClient, webAppId, options).setResultCallback(
+                    new ApplicationConnectionResultCallback(new LaunchWebAppListener() {
 
-                            @Override
-                            public void onFailure(ServiceCommandError error) {
-                                Util.postError(listener, error);
-                            }
-                        })
-                        );
+                        @Override
+                        public void onSuccess(WebAppSession webAppSession) {
+                            Util.postSuccess(listener, webAppSession);
+                        }
+
+                        @Override
+                        public void onFailure(ServiceCommandError error) {
+                            Util.postError(listener, error);
+                        }
+                    })
+                );
             }
         };
 

--- a/src/com/connectsdk/service/CastService.java
+++ b/src/com/connectsdk/service/CastService.java
@@ -1046,29 +1046,28 @@ public class CastService extends DeviceService implements MediaPlayer, MediaCont
                 public void onResult(ApplicationConnectionResult result) {
                     if (result.getStatus().isSuccess()) {
                         requestStatus(null);
-                        
-                        if (mWaitingForReconnect) {
-                            mWaitingForReconnect = false;
+                    }
 
-                            if (Cast.CastApi.getApplicationStatus(mApiClient) != null && currentAppId != null) {
-                                CastWebAppSession webAppSession = sessions.get(currentAppId);
+                    if (mWaitingForReconnect) {
+                        mWaitingForReconnect = false;
 
-                                webAppSession.connect(null);
-                            }
+                        if (Cast.CastApi.getApplicationStatus(mApiClient) != null && currentAppId != null) {
+                            CastWebAppSession webAppSession = sessions.get(currentAppId);
+
+                            webAppSession.connect(null);
                         }
-                        else {
-                            connected = true;
+                    }
+                    else {
+                        connected = true;
 
-                            reportConnected(true);
+                        reportConnected(true);
+                    }
+
+                    if (!commandQueue.isEmpty()) {
+                        for (ConnectionListener listener : commandQueue) {
+                            listener.onConnected();
+                            commandQueue.remove(listener);
                         }
-
-                        if (!commandQueue.isEmpty()) {
-                            for (ConnectionListener listener : commandQueue) {
-                                listener.onConnected();
-                                commandQueue.remove(listener);
-                            }
-                        }
-
                     }
                 }
             });


### PR DESCRIPTION
This is for issue: https://github.com/ConnectSDK/Connect-SDK-Android/issues/215#issuecomment-77568809

When first connect to the chromecast, it will join the current application, so that now, we can get  the previously loaded media's playstate and else.
