### PR TITLE
Fix on route remove

### DIFF
--- a/src/com/connectsdk/discovery/provider/CastDiscoveryProvider.java
+++ b/src/com/connectsdk/discovery/provider/CastDiscoveryProvider.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public class CastDiscoveryProvider implements DiscoveryProvider {
-    private static final long ROUTE_REMOVE_INTERVAL = 2000;
+    private static final long ROUTE_REMOVE_INTERVAL = 3000;
 
     private MediaRouter mMediaRouter;
     private MediaRouteSelector mMediaRouteSelector;
@@ -165,13 +165,11 @@ public class CastDiscoveryProvider implements DiscoveryProvider {
         return false;
     }
 
-
     private class MediaRouterCallback extends MediaRouter.Callback {
 
         @Override
         public void onRouteAdded(MediaRouter router, RouteInfo route) {
             super.onRouteAdded(router, route);
-            Log.d(Util.T, "Service [" + route.getName() + "] has been added");
 
             CastDevice castDevice = CastDevice.getFromBundle(route.getExtras());
             String uuid = castDevice.getDeviceId();
@@ -218,7 +216,6 @@ public class CastDiscoveryProvider implements DiscoveryProvider {
         @Override
         public void onRouteChanged(MediaRouter router, RouteInfo route) {
             super.onRouteChanged(router, route);
-            Log.d(Util.T, "Service [" + route.getName() + "] has been changed");
 
             CastDevice castDevice = CastDevice.getFromBundle(route.getExtras());
             String uuid = castDevice.getDeviceId();
@@ -262,9 +259,8 @@ public class CastDiscoveryProvider implements DiscoveryProvider {
         }
 
         @Override
-        public void onRouteRemoved(MediaRouter router, RouteInfo route) {
+        public void onRouteRemoved(final MediaRouter router, final RouteInfo route) {
             super.onRouteRemoved(router, route);
-            Log.d(Util.T, "Service [" + route.getName() + "] has been removed");
 
             CastDevice castDevice = CastDevice.getFromBundle(route.getExtras());
             String uuid = castDevice.getDeviceId();
@@ -280,6 +276,7 @@ public class CastDiscoveryProvider implements DiscoveryProvider {
                         for (String uuid : removedUUID) {
                             final ServiceDescription service = foundServices.get(uuid);
                             if (service != null) {
+                                Log.d(Util.T, "Service [" + route.getName() + "] has been removed");
                                 Util.runOnUI(new Runnable() {
 
                                     @Override


### PR DESCRIPTION
This pull request should fix these issues
- https://github.com/ConnectSDK/Connect-SDK-Android/issues/268
- https://github.com/ConnectSDK/Connect-SDK-Android/issues/258
- https://github.com/ConnectSDK/Connect-SDK-Android/issues/254

It's hard to reproduce this disconnect issue but I found this scenario for Nexus 4:
- Launch Android Sampler app
- Connect to a Chromecast device
- Play video
- Click `Cast screen` button in system notification screen
- onRouteRemoved is called and video is stopped in prev. version
