### PR TITLE
fix race condition

### DIFF
--- a/src/com/connectsdk/service/google_cast/CastServiceChannel.java
+++ b/src/com/connectsdk/service/google_cast/CastServiceChannel.java
@@ -58,7 +58,7 @@ public class CastServiceChannel implements Cast.MessageReceivedCallback{
 
             @Override
             public void run() {
-                if (mMessage == null) {
+                if (mMessage == null && session.getWebAppSessionListener() != null) {
                     session.getWebAppSessionListener().onReceiveMessage(session, message);
                 } else {
                     session.getWebAppSessionListener().onReceiveMessage(session, mMessage);


### PR DESCRIPTION
There is a null check at the top of onMessageReceived, but if the WebAppSessionListener is destroyed after that, it may cause the Runnable to crash.

Since upgrading to 1.5 I am seeing numerous crash reports from users because of this. Thanks.
